### PR TITLE
Bumped PCAxis.Core and PCAxis.Encryption

### DIFF
--- a/PCAxis.Sql/PCAxis.Sql.csproj
+++ b/PCAxis.Sql/PCAxis.Sql.csproj
@@ -46,8 +46,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="2.19.110" />
-    <PackageReference Include="PCAxis.Core" Version="1.0.3" />
-    <PackageReference Include="PCAxis.Encryption" Version="1.0.0" />
+    <PackageReference Include="PCAxis.Core" Version="1.1.0" />
+    <PackageReference Include="PCAxis.Encryption" Version="1.0.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Upgraded to the latest version of PC.Axis.Core that now contains PCAxis.Common and PCAxis.Px.Core classes.
Upgraded PC Axis.Encryption after security vulnerability. See https://github.com/statisticssweden/PCAxis.Encryption/pull/3